### PR TITLE
Fix: apostrophe in comments breaks parsing

### DIFF
--- a/update-code.js
+++ b/update-code.js
@@ -46,7 +46,7 @@ define((require) => {
         state.idx += 1
         state.lastLineStart = state.idx
         if (char === '') { break }
-      } else if (char === '\'') { // String - skip over
+      } else if (char === '\'' && !state.inLineComment && !state.inComment) { // String - skip over
         state.idx += 1
         parseString(state)
       } else if (char === '/' && state.str.charAt(state.idx+1) === '/' && !state.inLineComment && !state.inComment) { // // Comment start


### PR DESCRIPTION
An apostrophe inside a `//` comment (e.g. `// You're So Cool`) causes the parser to treat `'` as a string literal delimiter, calling `parseString()` which swallows all subsequent code looking for a closing quote that never comes.

The fix adds comment-state guards to the string literal check in `parseLinesAndComments()` — the same guards that already exist on the `//`, `/*`, and `*/` handlers in the same function.

**Before:** `} else if (char === '\'') {`
**After:** `} else if (char === '\'' && !state.inLineComment && !state.inComment) {`

---

Found while trying to make a LiMuT cover of "You're So Cool" from True Romance and spending an embarrassing amount of time wondering why nothing played. Claude found the bug, wrote the fix, and drafted this PR. I just mass-produced the keystrokes. The future is lazy and it is now. 🤖🎵
